### PR TITLE
Use higher res icon

### DIFF
--- a/thumbnailer/apk/apk-thumbnailer
+++ b/thumbnailer/apk/apk-thumbnailer
@@ -27,7 +27,7 @@ OUTPUT=$2
 HEIGHT=$3
 
 # get application icon
-ICON=`aapt d badging "$INPUT" | grep "application:" | sed 's/^.*icon=.\(.*\).$/\1/'`
+ICON=$(aapt d badging "$INPUT" | grep "application-icon" | sed 's/^.*icon-\(.*\):.\(.*\).$/\2/' | tail -1)
 
 # if icon exists, extract icon & generate thumbnail 
 if [ "$ICON" != "" ] ;


### PR DESCRIPTION
Just tried the script on GNOME Shell 3.14 on Arch and noticed that the produced icons are low res.
