### PR TITLE
Update video-convert2mkvaac-install.sh to support LinuxMint

### DIFF
--- a/video/video-convert2mkvaac-install.sh
+++ b/video/video-convert2mkvaac-install.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # Convert any video file to MKV with AAC audio and add midnight mode tracks
 
-# test Ubuntu distribution
+# test Ubuntu or Linux Minty distribution
 DISTRO=$(lsb_release -is 2>/dev/null)
-[ "${DISTRO}" != "Ubuntu" ] && { zenity --error --text="This automatic installation script is for Ubuntu only"; exit 1; }
+[ "${DISTRO}" != "LinuxMint" ] && [ "${DISTRO}" != "Ubuntu" ] && { zenity --error --text="This automatic installation script is for Ubuntu or Linux Mint"; exit 1; }
 
 # install yad
 IS_PRESENT=$(command -v yad)


### PR DESCRIPTION
Added detection of LinuxMint (after succesfull test in Linux Mint 17.2 "Rafaela" 32-bit)

It worked flawlessly and afterwards I tested using Nautilus Actions against an .mp4
Great and handy tool!

Is there any way to make it work in caja (the Nautilus fork of Linux Mint) directly?