### PR TITLE
Truncate long description

### DIFF
--- a/nautilus/extensions/exif-geotag.py
+++ b/nautilus/extensions/exif-geotag.py
@@ -121,6 +121,7 @@ class GeotagPropertyPage(GObject.GObject, Nautilus.PropertyPageProvider):
         geolocator = Nominatim()
         location = geolocator.reverse(strPosition)
         strDescription = location.address
+        strDescription = strDescription[:90]
 
         # write description to cache
         file = codecs.open(fileDesc, "w", "utf-8")


### PR DESCRIPTION
When the description is long enough, the dialog's width increases to much which is annoying.
So, the description now is truncated to 90 characters.

Other solutions may be better, like wrapping the description instead of truncate it.