### PR TITLE
gnomeshell-extension-manage: handle exception when no extension enabled

### DIFF
--- a/ubuntugnome/gnomeshell-extension-manage
+++ b/ubuntugnome/gnomeshell-extension-manage
@@ -138,11 +138,12 @@ then
     ${INSTALL_SUDO} chmod +r ${EXTENSION_PATH}/${EXTENSION_UUID}/*
 
     # list enabled extensions
-    EXTENSION_LIST=$(gsettings get org.gnome.shell enabled-extensions | sed 's/^.\(.*\).$/\1/')
+    EXTENSION_LIST=$(gsettings get org.gnome.shell enabled-extensions | sed 's/^@as //' | tr -d '[]')
 
     # if extension not already enabled, declare it
+    [ "${EXTENSION_LIST}" != "" ] && EXTENSION_LIST="${EXTENSION_LIST},"
     EXTENSION_ENABLED=$(echo ${EXTENSION_LIST} | grep ${EXTENSION_UUID})
-    [ "$EXTENSION_ENABLED" = "" ] && gsettings set org.gnome.shell enabled-extensions "[${EXTENSION_LIST},'${EXTENSION_UUID}']"
+    [ "$EXTENSION_ENABLED" = "" ] && gsettings set org.gnome.shell enabled-extensions "[${EXTENSION_LIST}'${EXTENSION_UUID}']"
 
     # success message
     echo "Gnome Shell version is ${GNOME_VERSION}."


### PR DESCRIPTION
When there is no extension enabled, gsetting will return '@as []' for enabled-extensions.

Use sed and tr to get rid of it, and don't add ',' when the list is empty.

This fixes #26 