### PR TITLE
Fix: cp: cannot create regular file '/home/user/.mozilla/firefox/cuvs…

### DIFF
--- a/mozilla/mozilla-extension-manager
+++ b/mozilla/mozilla-extension-manager
@@ -305,7 +305,7 @@ else
 	fi
 
 	# copy .xpi to system extension path
-	[ "${EXT_TYPE}" = "user" ] && cp -f "${ADDON_XPI}" "${EXT_PATH}/../${EXT_UID}.xpi" \
+	[ "${EXT_TYPE}" = "user" ] && mkdir -p "${EXT_PATH}/.." && cp -f "${ADDON_XPI}" "${EXT_PATH}/../${EXT_UID}.xpi" \
 	                           || sudo cp -f "${ADDON_XPI}" "${EXT_PATH}/../${EXT_UID}.xpi"
 
 	# extract extension to system extension path


### PR DESCRIPTION
Hi Nicolas,

cool script! I'm getting the following error without creating the directory to copy to first. Before running your script I created a `~/.mozilla` via `timeout 5 firefox`. I got Firefox 56.0 on Fedora 25.

```
[user@machine ~]$ mozilla-extension-manager --user --install https://addons.mozilla.org/firefox/downloads/latest/665872/addon-665872-latest.xpi
cp: cannot create regular file '/home/user/.mozilla/firefox/cuvso01u.default/extensions/../6asa42dfa4784fsf368g@youtubeconverter.me.xpi': No such file or directory
cp: cannot create regular file '/home/user/.mozilla/firefox/cuvso01u.default/extensions/../6asa42dfa4784fsf368g@youtubeconverter.me.xpi': No such file or directory
checkdir:  cannot create extraction directory: /home/user/.mozilla/firefox/cuvso01u.default/extensions/6asa42dfa4784fsf368g@youtubeconverter.me
           No such file or directory
checkdir:  cannot create extraction directory: /home/user/.mozilla/firefox/cuvso01u.default/extensions/6asa42dfa4784fsf368g@youtubeconverter.me
           No such file or directory
[success] install firefox user extension Youtube Mp3 Downloader, uid=6asa42dfa4784fsf368g@youtubeconverter.me, version=0.1
```