### PR TITLE
mozilla: fix extension manager list regression

### DIFF
--- a/mozilla/mozilla-extension-manager
+++ b/mozilla/mozilla-extension-manager
@@ -242,7 +242,7 @@ fi
 if [ "${EXT_ACTION}" = "list" ]
 then
 	# list installed XPI files
-	ARR_XPI=( $(ls ${EXT_PATH}/*.xpi) )
+	ARR_XPI=( $(ls ${EXT_PATH}/*.xpi ${EXT_PATH}/../*.xpi 2>/dev/null) )
 
 	# loop thru installed XPI
 	for FILE_XPI in "${ARR_XPI[@]}"


### PR DESCRIPTION
this commit https://github.com/azban/ubuntu-scripts/commit/607ea3e8d59c72ac05e4c614a7dbb08d931262bb#diff-b21b2d3a2d314dc3d4dfa7f91196764c
breaks the list action for extensions installed by this script.

steps to reproduce:
1) install extension
2) list extensions

also redirected stderr to /dev/null to ignore if ls cannot find files in a location, which is valid in some cases