### PR TITLE
bwrap: look for /etc/ImageMagick-6

### DIFF
--- a/nautilus/bwrap
+++ b/nautilus/bwrap
@@ -8,6 +8,7 @@ ARR_PARAM=( )
 
 # add both --ro-bind needed by thumbnailers using imagemagick tools
 [ -d "/etc/alternatives" ] && ARR_PARAM=( "${ARR_PARAM[@]}" "--ro-bind" "/etc/alternatives" "/etc/alternatives" )
+[ -d "/etc/ImageMagick-6" ] && ARR_PARAM=( "${ARR_PARAM[@]}" "--ro-bind" "/etc/ImageMagick-6" "/etc/ImageMagick-6" )
 [ -d "/var/cache/fontconfig" ] && ARR_PARAM=( "${ARR_PARAM[@]}" "--ro-bind" "/var/cache/fontconfig" "/var/cache/fontconfig" )
 
 # loop thru original parameters


### PR DESCRIPTION
to avoid this:

```
** (org.gnome.Nautilus:17322): DEBUG: 00:47:04.590: Failed to launch script: convert-im6.q16: unable to access configure file `delegates.xml' @ warning/configure.c/GetConfigureOptions/712.
convert-im6.q16: no decode delegate for this image format `WEBP' @ error/constitute.c/ReadImage/560.
convert-im6.q16: no images defined `png:/tmp/gnome-desktop-thumbnailer.png' @ error/convert.c/ConvertImageCommand/3258.
```

because `convert` from ImageMagick looks for `/etc/ImageMagick-6/delegates.xml` in some cases (like webp conversion).